### PR TITLE
Добавил возможность кастомизировать url элементов

### DIFF
--- a/IblockQuery.php
+++ b/IblockQuery.php
@@ -191,6 +191,9 @@ class IblockQuery
             $this->arNav,
             $this->arSort,
             $this->arSelect,
+            $this->sListPageUrl,
+            $this->sDetailPageUrl,
+            $this->sSectionPageUrl,
         ]));
 
         if ($this->obCache->initCache($this->nCacheTtl, $this->sCacheKey, $this->sCacheModule)) {

--- a/IblockQuery.php
+++ b/IblockQuery.php
@@ -49,6 +49,18 @@ class IblockQuery
      * @var array
      */
     private $arSelect = ['*'];
+    /**
+     * @var string
+     */
+    private $sListPageUrl = '';
+    /**
+     * @var string
+     */
+    private $sDetailPageUrl = '';
+    /**
+     * @var string
+     */
+    private $sSectionPageUrl = '';
 
     /**
      * IblockQuery constructor.
@@ -139,6 +151,36 @@ class IblockQuery
     }
 
     /**
+     * @param $sListPageUrl
+     * @return $this
+     */
+    public function listPageUrl($sListPageUrl)
+    {
+        $this->sListPageUrl = $sListPageUrl;
+        return $this;
+    }
+
+    /**
+     * @param $sDetailPageUrl
+     * @return $this
+     */
+    public function detailPageUrl($sDetailPageUrl)
+    {
+        $this->sDetailPageUrl = $sDetailPageUrl;
+        return $this;
+    }
+
+    /**
+     * @param $sSectionPageUrl
+     * @return $this
+     */
+    public function sectionPageUrl($sSectionPageUrl)
+    {
+        $this->sSectionPageUrl = $sSectionPageUrl;
+        return $this;
+    }
+
+    /**
      * @return mixed
      */
     private function getCache()
@@ -166,6 +208,7 @@ class IblockQuery
         $arItems = [];
 
         $dbResult = CIBlockElement::GetList($this->arSort, $this->arFilter, false, $this->arNav, $this->arSelect);
+        $dbResult->SetUrlTemplates($this->sDetailPageUrl, $this->sSectionPageUrl, $this->sListPageUrl);
 
         if ($this->bProperties) {
             while ($obItem = $dbResult->GetNextElement()) {
@@ -191,7 +234,8 @@ class IblockQuery
         $arSections = [];
 
         $dbResult = CIBlockSection::GetList($this->arSort, $this->arFilter, false, $this->arSelect);
-        while ($arSection = $dbResult->Fetch()) {
+        $dbResult->SetUrlTemplates($this->sDetailPageUrl, $this->sSectionPageUrl, $this->sListPageUrl);
+        while ($arSection = $dbResult->GetNext()) {
             $arSections[] = $arSection;
         }
 


### PR DESCRIPTION
Если в select указать LIST_PAGE_URL, DETAIL_PAGE_URL, SECTION_PAGE_URL, то можно было получить только ссылки по шаблонам, заданным в настройках инфоблока.
Теперь можно менять эти шаблоны при выборке
